### PR TITLE
Fix link to Visualizations page in menu.

### DIFF
--- a/templates/layouts/menu.jade
+++ b/templates/layouts/menu.jade
@@ -9,7 +9,7 @@ ul.nav.navbar-nav.navbar-right
           a(href=page.url) #{page.title}
 
   li
-    a(href='/budget-visuals.html') Visualizations
+    a(href='/budget-visuals') Visualizations
 
   li
     a(href='http://data.openoakland.org/dataset/city-of-oakland-budget', target='_blank') Data


### PR DESCRIPTION
Link to Visualizations page previously did not work, because it pointed to an html file that no longer exists.