### PR TITLE
Fix broken header link to data.openoakland.org budget dataset.

### DIFF
--- a/_src/_archived/fiveyear.html
+++ b/_src/_archived/fiveyear.html
@@ -74,7 +74,7 @@ BEGIN NAV
 					</ul>
 					</li>
 		<li class="divider"></li>
-		<li><a href="http://data.openoakland.org/dataset/city-of-oakland-budget" target="_blank">Data</a></li>
+		<li><a href="http://data.openoakland.org/dataset/city-oakland-budget" target="_blank">Data</a></li>
 		<li class="divider"></li>
 
 		<li class="has-dropdown"><a href="">Resources</a>

--- a/_src/_layout.jade
+++ b/_src/_layout.jade
@@ -51,7 +51,7 @@ html
                   a(href='/budget-visuals.html') Visualizations
 
                 li
-                  a(href='http://data.openoakland.org/dataset/city-of-oakland-budget', target='_blank') Data
+                  a(href='http://data.openoakland.org/dataset/city-oakland-budget', target='_blank') Data
 
                 li.dropdown
                   a.dropdown-toggle(href='#', data-toggle='dropdown')


### PR DESCRIPTION
Header link is currently broken because dataset slug removed "of"