### PR TITLE
Use HTTPS for all resources

### DIFF
--- a/_src/_layout.jade
+++ b/_src/_layout.jade
@@ -14,7 +14,7 @@ html
           ga('send', 'pageview');
 
     script(src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js").
-    script(src='http://code.jquery.com/jquery-migrate-1.2.1.js')
+    script(src='https://code.jquery.com/jquery-migrate-1.2.1.js')
     script(src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.2.0/js/bootstrap.min.js").
     script(src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.5/d3.min.js").
 
@@ -103,4 +103,4 @@ html
               li
                 a(href="feedback.html") Give Feedback
 
-    link(href='http://fonts.googleapis.com/css?family=Arvo:400,700', rel='stylesheet', type='text/css')
+    link(href='https://fonts.googleapis.com/css?family=Arvo:400,700', rel='stylesheet', type='text/css')


### PR DESCRIPTION
Firefox blocks resources that are loaded over HTTP for an otherwise HTTPS connection, so this commit makes the resources from JQuery and Google be loaded over HTTPS.