### PR TITLE
Issue #134 Added an MIT-License to the repository.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 OpenOakland 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
In this commit, I reviewed the various open source licenses to find the best-suited license for this repository. 

I started off with my research reading [ https://help.github.com/en/articles/licensing-a-repository](url) and [https://choosealicense.com/](url) .
 
Eventually, I understood that there were broadly two categories of licensing we need to worry about in the open source community - permissive licenses (lenient) and licenses that impose the distribution (strict). Furthermore, there exist licenses that lean towards the commercial progression of open source technologies which seemed irrelevant to the non-profit and educational outlook of OpenOakland.

All open source licenses are mapped and compared side to side here - [https://choosealicense.com/appendix/](url)
  
To invite free use and developments to this repository with no restrictions a permissive license is the best route to take. But which one? We could choose either the BSD-2-clause or the MIT License. The MIT license is the go-to license within most OpenOakland repositories,  the most simple and has the ability to be coupled with other licenses (BSD included) in the future. 
