### PR TITLE
fix link to Code for Oakland

### DIFF
--- a/_src/who-we-are.jade
+++ b/_src/who-we-are.jade
@@ -51,5 +51,5 @@
           li Steve Spiker
           li Tom Fite
           li And the rest of the 
-            a(href='http://codeforoakland.org/', target='_blank') Code for Oakland
+            a(href='https://openoakland.org/', target='_blank') OpenOakland
             |  crew...

--- a/_src/who-we-are.jade
+++ b/_src/who-we-are.jade
@@ -51,5 +51,7 @@
           li Steve Spiker
           li Tom Fite
           li And the rest of the 
-            a(href='https://openoakland.org/', target='_blank') OpenOakland
+            a(
+              href='https://oaklandnorth.net/2012/07/23/code-for-oakland-challenges-developers-to-turn-public-data-into-an-app/', target='_blank'
+            ) Code for Oakland
             |  crew...


### PR DESCRIPTION
resolves #135 

Changes Code for Oakland link at the bottom of Who We Are page to point to an [Oakland North article](https://oaklandnorth.net/2012/07/23/code-for-oakland-challenges-developers-to-turn-public-data-into-an-app/) suggested by @adstiles