### PR TITLE
Fix footer typo

### DIFF
--- a/_src/_layout.jade
+++ b/_src/_layout.jade
@@ -97,12 +97,12 @@ html
             img(alt="Creative Commons License", style="border-width:0", src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png")
           .col-md-6.col-sm-9
             p
-              | Open Budget: Oakland is an open-source project by
-              a(href="http://openoakland.org") OpenOakland
+              | Open Budget: Oakland is an open-source project by #{' '}
+              a(href="https://openoakland.org") OpenOakland
               |  to help citizens better understand Oakland's spending and budget process.
             ul.list-inline
               li
-                a(href="http://openoakland.org")
+                a(href="https://openoakland.org")
                   img(src="/images/global/openoakland-logo.png" width="150" alt="OpenOakland")
               li
                 a(href="https://twitter.com/openbudgetoak")


### PR DESCRIPTION
There was a missing space in the footer. This should fix it. See image below.

Also changed links to https since they the site is https.

<img width="668" alt="image" src="https://user-images.githubusercontent.com/46909/85622509-c98c2a80-b61b-11ea-9353-2b907dcb7f24.png">

(thank you for your work!)