### PR TITLE
Updated News

### DIFF
--- a/_src/news.jade
+++ b/_src/news.jade
@@ -5,19 +5,19 @@
       div
         h2.subheader News
         p
-          a(href='http://blogs.kqed.org/newsfix/2013/05/28/bay-area-participatory-budgeting', target='_blank') KQED: In Vallejo, Citizens Directly Choosing Projects to Fund
-        p
-          | "Adam Stiles of Open Budget: Oakland, which creates online resources to help people make sense of city spending, said the group's new visualization tools, also known as 'civic hacking,' help translate between city officials and the community. 'What we are trying to do is create a platform where people can easily understand the budget,' Stiles said. 'Then, based on what they see, have a more informed discussion about it and then find out how to get more involved and participate in the budget process.'"
-          a(href='http://blogs.kqed.org/newsfix/2013/05/28/bay-area-participatory-budgeting', target='_blank') Read more.
+          a(href='https://www.oaklandca.gov/projects/fy-2019-2020-budget-process-1', target='_blank') City of Oakland's Fiscal Year 2019-2021 Budget
           p
-            a(href='http://codeforamerica.org/2013/05/14/10-ways-civic-hacking-is-good-for-cities', target='_blank') Code for America: Ten Ways Civic Hacking is Good for Cities
-            p
-              a(href='http://www.eastbayexpress.com/SevenDays/archives/2013/04/30/hacking-oaklands-budget', target='_blank') East Bay Express: Hacking Oakland's Budget
+            a(href='https://www.govtech.com/budget-finance/The-Disruption-Pipeline-Government-Citizen-Relationships.html', target='_blank') Government Technology: Disruptive Technology that Could Transform Government-Citizen Relationships
+          p
+            | "In Oakland, Calif., OpenOakland, a civic-tech innovation brigade from Code for America, has developed a visualization tool called Open Budget to allow the public to explore the city budget. A conversation feature lets users ask questions and discuss every line item of the city budget."
+            a(href='https://www.govtech.com/budget-finance/The-Disruption-Pipeline-Government-Citizen-Relationships.html', target='_blank') Read more.
               p
-                a(href='http://blog.okfn.org/2013/04/29/open-budget-oakland-and-openspending/', target='_blank') OKFN: From Hackathon to Civic Collaboration
-                p
-                  a(href='http://www.oaklandrising.org/blog/our-town-our-budget-what-does-public-safety-really-look', target='_blank') Oakland Rising: Our Town, Our Budget: What Does Public Safety Really Look Like?
+                a(href='https://www.kalw.org/post/volunteers-hack-technology-improve-oakland-city-government', target='_blank') KALW: Volunteers hack technology to improve Oakland city government
+                p          
+                  a(href='https://www.eastbayexpress.com/SevenDays/archives/2013/04/30/hacking-oaklands-budget', target='_blank') East Bay Express: Hacking Oakland's Budget
                   p
-                    a(href='http://openoakland.org/opening-oaklands-budget', target='_blank') OpenOakland: Opening Oakland’s Budget
+                    a(href='https://blog.okfn.org/2013/04/29/open-budget-oakland-and-openspending/', target='_blank') OKFN: From Hackathon to Civic Collaboration
                     p
-                      a(href='http://techpresident.com/news/23749/oakland-gets-new-data-visualization-site-its-budget', target='_blank') Tech President: Oakland Gets A New Data Visualization Site for Its Budget
+                      a(href='https://www.oaklandrising.org/blog/our-town-our-budget-what-does-public-safety-really-look', target='_blank') Oakland Rising: Our Town, Our Budget: What Does Public Safety Really Look Like?
+                      p
+                        a(href='http://techpresident.com/news/23749/oakland-gets-new-data-visualization-site-its-budget', target='_blank') Tech President: Oakland Gets A New Data Visualization Site for Its Budget


### PR DESCRIPTION
Fixed some issues from [Update Content issue #129 ](https://github.com/openoakland/openbudgetoakland/issues/129)

Removed dead links:

- [KQED link and text](http://blogs.kqed.org/newsfix/2013/05/28/bay-area-participatory-budgeting)
- [Open Oakland link](http://openoakland.org/opening-oaklands-budget)
- [Article link from Oakland Rising](http://www.oaklandrising.org/blog/our-town-our-budget-what-does-public-safety-really-look)

Added :

- [City Budge link](https://www.oaklandca.gov/projects/fy-2019-2020-budget-process-1)
- [Article link and text from Government Technology](https://www.govtech.com/budget-finance/The-Disruption-Pipeline-Government-Citizen-Relationships.html)
- [Article link from KALW](https://www.kalw.org/post/volunteers-hack-technology-improve-oakland-city-government)