### PR TITLE
remove some broken links

### DIFF
--- a/_src/oakland-budget-basics.pug
+++ b/_src/oakland-budget-basics.pug
@@ -33,15 +33,3 @@ block content
                   li
                     a(href='https://oakland.mindmixer.com/oakland-budget-prioritization') Oakland Budget Prioritization
                     | : How would you allocate the City's General Fund budget?
-    //
-      Included JS Files (Uncompressed)
-    //
-        <script src="javascripts/jquery.js"></script><script src="javascripts/jquery.foundation.mediaQueryToggle.js"></script><script src="javascripts/jquery.foundation.forms.js"></script><script src="javascripts/jquery.foundation.reveal.js"></script><script src="javascripts/jquery.foundation.orbit.js"></script><script src="javascripts/jquery.foundation.navigation.js"></script><script src="javascripts/jquery.foundation.buttons.js"></script><script src="javascripts/jquery.foundation.tabs.js"></script><script src="javascripts/jquery.foundation.tooltips.js"></script><script src="javascripts/jquery.foundation.accordion.js"></script><script src="javascripts/jquery.placeholder.js"></script><script src="javascripts/jquery.foundation.alerts.js"></script><script src="javascripts/jquery.foundation.topbar.js"></script><script src="javascripts/jquery.foundation.joyride.js"></script><script src="javascripts/jquery.foundation.clearing.js"></script><script src="js/jquery.foundation.magellan.js"></script>
-
-    //
-      Included JS Files (Compressed)
-    script(src='/js/old/jquery.js')
-    script(src='/js/old/foundation.min.js')
-    //
-      Initialize JS Plugins
-    script(src='/js/old/app.js')

--- a/_src/partials/treeIntro.pug
+++ b/_src/partials/treeIntro.pug
@@ -1,3 +1,3 @@
 p Select year and account (revenues or expenses). Click on a fund to see the departments that receive its funding. Click on that department to see its spending or revenue. This page only shows "adopted budgets"; that is, budgets passed by the City Council.
 
-p The <strong>General Fund</strong> — roughly 40% of Oakland's total budget -- is decided by a <a href="/budget-process.html">budget process</a> that includes private and public meetings, surveys, and negotiations. The other 60% of the budget comes from taxes, ballot measures, grants, fees, and other sources.
+p The <strong>General Fund</strong> — roughly 40% of Oakland's total budget -- is decided by a <a href="/budget-process">budget process</a> that includes private and public meetings, surveys, and negotiations. The other 60% of the budget comes from taxes, ballot measures, grants, fees, and other sources.

--- a/_src/tools-projects.pug
+++ b/_src/tools-projects.pug
@@ -23,7 +23,7 @@ block content
             | Budget visualization resources
           ul.disc
             li
-              a(href='http://www.openspending.org', target='_blank') OpenSpending
+              a(href='https://community.openspending.org/', target='_blank') OpenSpending
             li
               a(href='http://d3js.org/', target='_blank') D3
             li
@@ -48,14 +48,6 @@ block content
             li
               a(href='http://www.checkbooknyc.com/', target='_blank') Checkbook NYC
             li
-              a(href='http://paloalto.delphi.us', target='_blank') Palo Alto
-            li
-              a(href='http://www.interislandterminal.org/assets/scripts/viz/hnlbudget/sankey.html', target='_blank') Honolulu
-            li
-              a(href='http://www.berlin.de/sen/finanzen/haushalt/haushaltsplan/artikel.5697.php', target='_blank') Berlin
-            li
-              a(href='http://budget.brettmandel.com', target='_blank') Philadelphia
-            li
               a(href='http://longbeach.budgetchallenge.org/pages/overview', target='_blank') Long Beach
           h4.subheader Counties
           ul.disc
@@ -67,8 +59,6 @@ block content
               a(href='http://www.budgetchallenge.org/', target='_blank') California Budget Challenge
             li
               a(href='http://demo.outline.com/#budget/2', target='_blank') Massachusetts Budget Simulator
-            li
-              a(href='http://www.ofm.wa.gov/budget13/visualization/default.asp', target='_blank') Washington Governor's Proposed 2013-15 Budget
           h4.subheader Countries
           ul.disc
             li
@@ -77,15 +67,11 @@ block content
               a(href='http://wheredidmytaxdollarsgo.com/', target='_blank') Where Did My Tax Dollars Go? (US)
             li
               a(href='http://www.nytimes.com/interactive/2012/02/13/us/politics/2013-budget-proposal-graphic.html?_r=0', target='_blank') Obama’s 2013 Budget Proposal
-              li
-                a(href='http://wheredoesmymoneygo.org/', target='_blank') Where Does My Money Go? (UK)
-              li
-                a(href='http://peterkrantz.com/v11n/statsbudget-2013/', target='_blank') Statsbudgeten 2013 (Sweden)
-              li
-                a(href='http://bund.offenerhaushalt.de/', target='_blank') OffenerHaushalt.de (Germany)
-              li
-                a(href='http://cameroon.openspending.org', target='_blank') Cameroon Budget Inquirer
-              li
-                a(href='http://slovakia.openspending.org', target='_blank') Slovakia's Municipal Budgets
-              li
-                a(href='http://www.budgetstories.md', target='_blank') Budget Stories (Moldova)
+            li
+              a(href='http://peterkrantz.com/v11n/statsbudget-2013/', target='_blank') Statsbudgeten 2013 (Sweden)
+            li
+              a(href='http://cameroon.openspending.org', target='_blank') Cameroon Budget Inquirer
+            li
+              a(href='http://slovakia.openspending.org', target='_blank') Slovakia's Municipal Budgets
+            li
+              a(href='http://www.budgetstories.md', target='_blank') Budget Stories (Moldova)

--- a/_src/what-we-do.pug
+++ b/_src/what-we-do.pug
@@ -17,7 +17,7 @@ block content
           p(align='right')
             small
               | Image: 
-              a(href='http://www.openspending.org/', target='_blank') OpenSpending
+              a(href='https://community.openspending.org/', target='_blank') OpenSpending
         h2.subheader What we do
         p
           | Open Budget: Oakland helps people learn more about the city budget, so they can talk about it with each other, with city council members, and with city staff.  We want people to know how their city works and how it could work better.
@@ -39,15 +39,3 @@ block content
           | Now that you know our goals, 
           a(href='/feedback') share your ideas here
           | .
-  //
-    Included JS Files (Uncompressed)
-  //
-      <script src="javascripts/jquery.js"></script><script src="javascripts/jquery.foundation.mediaQueryToggle.js"></script><script src="javascripts/jquery.foundation.forms.js"></script><script src="javascripts/jquery.foundation.reveal.js"></script><script src="javascripts/jquery.foundation.orbit.js"></script><script src="javascripts/jquery.foundation.navigation.js"></script><script src="javascripts/jquery.foundation.buttons.js"></script><script src="javascripts/jquery.foundation.tabs.js"></script><script src="javascripts/jquery.foundation.tooltips.js"></script><script src="javascripts/jquery.foundation.accordion.js"></script><script src="javascripts/jquery.placeholder.js"></script><script src="javascripts/jquery.foundation.alerts.js"></script><script src="javascripts/jquery.foundation.topbar.js"></script><script src="javascripts/jquery.foundation.joyride.js"></script><script src="javascripts/jquery.foundation.clearing.js"></script><script src="js/jquery.foundation.magellan.js"></script>
-
-  //
-    Included JS Files (Compressed)
-  script(src='/js/old/jquery.js')
-  script(src='/js/old/foundation.min.js')
-  //
-    Initialize JS Plugins
-  script(src='/js/old/app.js')


### PR DESCRIPTION
#251 

Removed some but:

1. compare seems broken
2. Everything on budget-visuals seems broken
3. font problems
```
Parent URL http://localhost:8011/styles/main.css
Real URL   http://localhost:8011/fonts/bootstrap/glyphicons-halflings-regular.eot
Real URL   http://localhost:8011/fonts/bootstrap/glyphicons-halflings-regular.woff2
Real URL   http://localhost:8011/fonts/bootstrap/glyphicons-halflings-regular.woff
Real URL   http://localhost:8011/fonts/bootstrap/glyphicons-halflings-regular.ttf
Real URL   http://localhost:8011/fonts/bootstrap/glyphicons-halflings-regular.svg#glyphicons_halflingsregular
```
